### PR TITLE
Add info about cargo doc --open

### DIFF
--- a/project-continuation/doc-example/README.md
+++ b/project-continuation/doc-example/README.md
@@ -1,4 +1,5 @@
 Generate documentation with `cargo doc`. See your newly generated web documentation by opening `./target/doc/simplest/index.html`.
+You can also run `cargo doc --open` to do both in one step.
 
 Run documentation tests with `cargo test`.
 


### PR DESCRIPTION
GitHub automatically adds a newline at the last line if there isn't one, so that's why it shows up on the diff.